### PR TITLE
Allow username editing, Redesigned Toast Event Handling, More Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ completed.
 - Copying usernames and passwords to the clipboard.
 - Password generator that creates randomised and complex passwords.
 - Saving passwords for different accounts.
+- Editing saved usernames and passwords.
 - Login using a passcode to protect your passwords from people snooping on your phone. If a user is
   inactive for more than 10 minutes, you will be automatically logged out.
 - All data is stored offline using a SQLite database.
@@ -49,7 +50,6 @@ completed.
 
 - Adding non-intrusive ads. Big focus on **non-intrusive** as I hate all the annoying ads that
   plague freemium mobile applications with a passion.
-- Allow username editing
 
 ### Features that I might add in the future (No timeline)
 

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/activities/MainActivity.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/activities/MainActivity.kt
@@ -29,7 +29,6 @@ import com.vinsonb.password.manager.kotlin.extensions.showToast
 import com.vinsonb.password.manager.kotlin.ui.features.bottomnavmenu.BottomNavMenu
 import com.vinsonb.password.manager.kotlin.ui.features.createlogin.CreateLoginScreen
 import com.vinsonb.password.manager.kotlin.ui.features.createlogin.CreateLoginViewModel
-import com.vinsonb.password.manager.kotlin.ui.features.credits.CreditsDialog
 import com.vinsonb.password.manager.kotlin.ui.features.forgotpasscode.ForgotPasscodeViewModel
 import com.vinsonb.password.manager.kotlin.ui.features.login.LoginScreen
 import com.vinsonb.password.manager.kotlin.ui.features.login.LoginViewModel
@@ -39,7 +38,6 @@ import com.vinsonb.password.manager.kotlin.ui.features.passwordgenerator.Passwor
 import com.vinsonb.password.manager.kotlin.ui.features.saveaccount.SaveAccountScreen
 import com.vinsonb.password.manager.kotlin.ui.features.saveaccount.SaveAccountViewModel
 import com.vinsonb.password.manager.kotlin.ui.features.topnavmenu.TopNavMenu
-import com.vinsonb.password.manager.kotlin.ui.features.topnavmenu.TopNavMenuItem
 import com.vinsonb.password.manager.kotlin.ui.features.viewaccount.ViewAccountScreen
 import com.vinsonb.password.manager.kotlin.ui.theme.PassVaultTheme
 import com.vinsonb.password.manager.kotlin.utilities.Constants
@@ -54,7 +52,6 @@ import java.time.LocalTime
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private var accounts: List<Account> = listOf()
-    private var isCreditsDialogVisible by mutableStateOf(false)
     private var isBottomNavMenuVisible by mutableStateOf(true)
     private var isTopNavMenuVisible by mutableStateOf(true)
     private var isTopNavMenuItemsVisible by mutableStateOf(true)
@@ -64,25 +61,6 @@ class MainActivity : AppCompatActivity() {
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var csvLauncher: ActivityResultLauncher<String>
     private lateinit var createCsvLauncher: ActivityResultLauncher<String>
-
-    private val topNavMenuItems = arrayOf(
-        TopNavMenuItem(
-            itemNameRes = R.string.menu_item_import_csv,
-            action = ::importCsv,
-        ),
-        TopNavMenuItem(
-            itemNameRes = R.string.menu_item_export_csv,
-            action = ::exportCsv,
-        ),
-        TopNavMenuItem(
-            itemNameRes = R.string.menu_item_credits,
-            action = ::showCreditsDialog,
-        ),
-        TopNavMenuItem(
-            itemNameRes = R.string.menu_item_logout,
-            action = ::logout,
-        ),
-    )
 
     private val accountViewModel: AccountViewModel by viewModels()
     private val loginViewModel: LoginViewModel by viewModels()
@@ -136,8 +114,10 @@ class MainActivity : AppCompatActivity() {
                         if (isTopNavMenuVisible) {
                             TopNavMenu(
                                 title = topNavMenuTitle,
-                                menuItems = topNavMenuItems,
                                 isMenuVisible = isTopNavMenuItemsVisible,
+                                importCsv = ::importCsv,
+                                exportCsv = ::exportCsv,
+                                logout = ::logout,
                             )
                         }
                     },
@@ -192,10 +172,6 @@ class MainActivity : AppCompatActivity() {
                             }
                         }
                     }
-                }
-
-                if (isCreditsDialogVisible) {
-                    CreditsDialog { isCreditsDialogVisible = false }
                 }
             }
         }
@@ -287,10 +263,6 @@ class MainActivity : AppCompatActivity() {
             }
             else -> ""
         }
-    }
-
-    private fun showCreditsDialog() {
-        isCreditsDialogVisible = true
     }
 
     // region end navigation methods

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/createlogin/CreateLoginViewModel.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/createlogin/CreateLoginViewModel.kt
@@ -4,8 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.vinsonb.password.manager.kotlin.extensions.stateIn
 import com.vinsonb.password.manager.kotlin.ui.features.forgotpasscode.ForgotPasscodeViewModel
 import com.vinsonb.password.manager.kotlin.utilities.Constants.Password.PASSCODE_MAX_LENGTH
-import com.vinsonb.password.manager.kotlin.utilities.EventFlow
-import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEvent
+import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEventFlow
 import com.vinsonb.password.manager.kotlin.utilities.simpleToastEventFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,7 +16,7 @@ import kotlinx.coroutines.flow.update
 class CreateLoginViewModel(
     private val scope: CoroutineScope,
     private val _createLogin: (String, String, String) -> Unit,
-) : ViewModel(), EventFlow<SimpleToastEvent> by simpleToastEventFlow(scope) {
+) : ViewModel(), SimpleToastEventFlow by simpleToastEventFlow(scope) {
 
     private val _stateFlow = MutableStateFlow(CreateLoginState())
     val stateFlow = _stateFlow.stateIn(scope, CreateLoginState())

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeModels.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeModels.kt
@@ -1,20 +1,15 @@
 package com.vinsonb.password.manager.kotlin.ui.features.forgotpasscode
 
 import com.vinsonb.password.manager.kotlin.R
-import com.vinsonb.password.manager.kotlin.ui.features.forgotpasscode.ForgotPasscodeError.EmptyInputError
 import com.vinsonb.password.manager.kotlin.utilities.TextResIdProvider
 import com.vinsonb.password.manager.kotlin.utilities.textResIdEmptyInputProvider
 import com.vinsonb.password.manager.kotlin.utilities.textResIdProvider
 
-sealed interface ForgotPasscodeState {
-    object Hidden : ForgotPasscodeState
-
-    data class Visible(
-        val secretAnswerError: ForgotPasscodeError = EmptyInputError,
-        val passcodeError: ForgotPasscodeError = EmptyInputError,
-        val repeatPasscodeError: ForgotPasscodeError = EmptyInputError,
-    ) : ForgotPasscodeState
-}
+data class ForgotPasscodeState(
+    val secretAnswerError: ForgotPasscodeError = ForgotPasscodeError.EmptyInputError,
+    val passcodeError: ForgotPasscodeError = ForgotPasscodeError.EmptyInputError,
+    val repeatPasscodeError: ForgotPasscodeError = ForgotPasscodeError.EmptyInputError,
+)
 
 sealed interface ForgotPasscodeError {
     object None : ForgotPasscodeError

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeViewModel.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeViewModel.kt
@@ -5,8 +5,8 @@ import com.vinsonb.password.manager.kotlin.di.CoroutineDispatchers
 import com.vinsonb.password.manager.kotlin.extensions.stateIn
 import com.vinsonb.password.manager.kotlin.ui.features.createlogin.CreateLoginViewModel
 import com.vinsonb.password.manager.kotlin.utilities.Constants.Password.PASSCODE_MAX_LENGTH
-import com.vinsonb.password.manager.kotlin.utilities.EventFlow
 import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEvent
+import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEventFlow
 import com.vinsonb.password.manager.kotlin.utilities.simpleToastEventFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +19,7 @@ class ForgotPasscodeViewModel(
     private val scope: CoroutineScope,
     private val savedSecretAnswer: String,
     private val saveNewPasscode: (String) -> Boolean,
-) : ViewModel(), EventFlow<SimpleToastEvent> by simpleToastEventFlow(scope) {
+) : ViewModel(), SimpleToastEventFlow by simpleToastEventFlow(scope) {
 
     constructor(
         dispatchers: CoroutineDispatchers,

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeViewModel.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeViewModel.kt
@@ -31,66 +31,54 @@ class ForgotPasscodeViewModel(
         saveNewPasscode = saveNewPasscode,
     )
 
-    private val _stateFlow = MutableStateFlow<ForgotPasscodeState>(ForgotPasscodeState.Hidden)
-    val stateFlow = _stateFlow.stateIn(scope = scope, initialValue = ForgotPasscodeState.Hidden)
+    private val _stateFlow = MutableStateFlow(ForgotPasscodeState())
+    val stateFlow = _stateFlow.stateIn(scope = scope, initialValue = ForgotPasscodeState())
 
     fun validateSecretAnswer(secretAnswer: String) {
-        if (_stateFlow.value is ForgotPasscodeState.Visible) {
-            val errorState = when {
-                secretAnswer.isBlank() -> ForgotPasscodeError.EmptyInputError
-                secretAnswer != savedSecretAnswer -> ForgotPasscodeError.SecretAnswerMismatchError
-                else -> ForgotPasscodeError.None
-            }
-            _stateFlow.update {
-                (it as ForgotPasscodeState.Visible).copy(secretAnswerError = errorState)
-            }
+        val errorState = when {
+            secretAnswer.isBlank() -> ForgotPasscodeError.EmptyInputError
+            secretAnswer != savedSecretAnswer -> ForgotPasscodeError.SecretAnswerMismatchError
+            else -> ForgotPasscodeError.None
+        }
+        _stateFlow.update {
+            it.copy(secretAnswerError = errorState)
         }
     }
 
     fun validatePasscode(passcode: String, repeatPasscode: String) {
-        if (_stateFlow.value is ForgotPasscodeState.Visible) {
-            val errorState = when {
-                passcode.isBlank() -> ForgotPasscodeError.EmptyInputError
-                passcode.length != PASSCODE_MAX_LENGTH ->
-                    ForgotPasscodeError.InvalidDigitsError
-                else -> ForgotPasscodeError.None
-            }
-            _stateFlow.update {
-                (it as ForgotPasscodeState.Visible).copy(passcodeError = errorState)
-            }
-            validateRepeatPasscode(passcode, repeatPasscode)
+        val errorState = when {
+            passcode.isBlank() -> ForgotPasscodeError.EmptyInputError
+            passcode.length != PASSCODE_MAX_LENGTH ->
+                ForgotPasscodeError.InvalidDigitsError
+            else -> ForgotPasscodeError.None
         }
+        _stateFlow.update {
+            it.copy(passcodeError = errorState)
+        }
+        validateRepeatPasscode(passcode, repeatPasscode)
     }
 
     fun validateRepeatPasscode(passcode: String, repeatPasscode: String) {
-        if (_stateFlow.value is ForgotPasscodeState.Visible) {
-            val errorState = when {
-                repeatPasscode.isBlank() -> ForgotPasscodeError.EmptyInputError
-                repeatPasscode.length != PASSCODE_MAX_LENGTH ->
-                    ForgotPasscodeError.InvalidDigitsError
-                passcode != repeatPasscode -> ForgotPasscodeError.PasscodeMismatchError
-                else -> ForgotPasscodeError.None
-            }
-            _stateFlow.update {
-                (it as ForgotPasscodeState.Visible).copy(repeatPasscodeError = errorState)
-            }
+        val errorState = when {
+            repeatPasscode.isBlank() -> ForgotPasscodeError.EmptyInputError
+            repeatPasscode.length != PASSCODE_MAX_LENGTH ->
+                ForgotPasscodeError.InvalidDigitsError
+            passcode != repeatPasscode -> ForgotPasscodeError.PasscodeMismatchError
+            else -> ForgotPasscodeError.None
+        }
+        _stateFlow.update {
+            it.copy(repeatPasscodeError = errorState)
         }
     }
 
-    fun resetPasscode(passcode: String) {
-        if (saveNewPasscode(passcode)) {
-            dismissDialog()
-            sendEvent(SimpleToastEvent.ShowSucceeded)
-        } else {
-            sendEvent(SimpleToastEvent.ShowFailed)
+    fun resetPasscode(passcode: String): Boolean {
+        return saveNewPasscode(passcode).also { isSaved ->
+            if (isSaved) {
+                _stateFlow.update { ForgotPasscodeState() }
+                sendEvent(SimpleToastEvent.ShowSucceeded)
+            } else {
+                sendEvent(SimpleToastEvent.ShowFailed)
+            }
         }
-    }
-
-    fun showDialog() {
-        _stateFlow.update { ForgotPasscodeState.Visible() }
-    }
-
-    fun dismissDialog() {
-        _stateFlow.update { ForgotPasscodeState.Hidden }
     }
 }

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/saveaccount/SaveAccountScreen.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/saveaccount/SaveAccountScreen.kt
@@ -10,11 +10,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.vinsonb.password.manager.kotlin.R
 import com.vinsonb.password.manager.kotlin.database.enitities.Account
+import com.vinsonb.password.manager.kotlin.extensions.showToast
 import com.vinsonb.password.manager.kotlin.ui.components.CustomTextField
 import com.vinsonb.password.manager.kotlin.ui.theme.PassVaultTheme
 import com.vinsonb.password.manager.kotlin.utilities.ScreenPreviews
@@ -24,6 +26,12 @@ import com.vinsonb.password.manager.kotlin.utilities.clearMutableStateStrings
 
 @Composable
 fun SaveAccountScreen(viewModel: SaveAccountViewModel) {
+    val toastState by viewModel.eventFlow.collectAsState(initial = SimpleToastEvent.None)
+    ToastHandler(
+        toastState = toastState,
+        resetToastState = { viewModel.sendEvent(SimpleToastEvent.None) },
+    )
+
     val state by viewModel.stateFlow.collectAsState()
     val shouldClearAllInput = viewModel.eventFlow.collectAsState(
         initial = SimpleToastEvent.None
@@ -39,6 +47,25 @@ fun SaveAccountScreen(viewModel: SaveAccountViewModel) {
         saveAccount = viewModel::saveAccount,
         resetEvent = viewModel::resetEvent,
     )
+}
+
+@Composable
+private fun ToastHandler(
+    toastState: SimpleToastEvent,
+    resetToastState: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    LaunchedEffect(toastState) {
+        when (toastState) {
+            SimpleToastEvent.None -> {}
+            SimpleToastEvent.ShowFailed ->
+                context.showToast(R.string.error_save_unsuccessful)
+            SimpleToastEvent.ShowSucceeded ->
+                context.showToast(R.string.success_save_account)
+        }
+        resetToastState()
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/saveaccount/SaveAccountViewModel.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/saveaccount/SaveAccountViewModel.kt
@@ -5,8 +5,8 @@ import com.vinsonb.password.manager.kotlin.database.AccountRepository
 import com.vinsonb.password.manager.kotlin.database.enitities.Account
 import com.vinsonb.password.manager.kotlin.di.CoroutineDispatchers
 import com.vinsonb.password.manager.kotlin.extensions.stateIn
-import com.vinsonb.password.manager.kotlin.utilities.EventFlow
 import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEvent
+import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEventFlow
 import com.vinsonb.password.manager.kotlin.utilities.simpleToastEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +19,7 @@ import javax.inject.Inject
 class SaveAccountViewModel(
     private val scope: CoroutineScope,
     private val insertAccount: suspend (Account) -> Boolean,
-) : ViewModel(), EventFlow<SimpleToastEvent> by simpleToastEventFlow(scope) {
+) : ViewModel(), SimpleToastEventFlow by simpleToastEventFlow(scope) {
 
     @Inject
     constructor(

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/topnavmenu/TopNavMenu.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/topnavmenu/TopNavMenu.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import com.vinsonb.password.manager.kotlin.R
+import com.vinsonb.password.manager.kotlin.ui.features.credits.CreditsDialog
 import com.vinsonb.password.manager.kotlin.ui.theme.PassVaultTheme
 import com.vinsonb.password.manager.kotlin.utilities.ComponentPreviews
 
@@ -21,11 +22,35 @@ import com.vinsonb.password.manager.kotlin.utilities.ComponentPreviews
 @Composable
 fun TopNavMenu(
     title: String,
-    menuItems: Array<TopNavMenuItem>,
-    isMenuVisible: Boolean = true,
+    isMenuVisible: Boolean,
+    importCsv: () -> Unit,
+    exportCsv: () -> Unit,
+    logout: () -> Unit,
 ) {
-    var isMenuExpanded by rememberSaveable { mutableStateOf(false) }
+    val isCreditsDialogVisible = rememberSaveable { mutableStateOf(false) }
+    DialogHandler(isDialogVisible = isCreditsDialogVisible)
 
+    val topNavMenuItems = remember {
+        arrayOf(
+            TopNavMenuItem(
+                itemNameRes = R.string.menu_item_import_csv,
+                action = importCsv,
+            ),
+            TopNavMenuItem(
+                itemNameRes = R.string.menu_item_export_csv,
+                action = exportCsv,
+            ),
+            TopNavMenuItem(
+                itemNameRes = R.string.menu_item_credits,
+                action = { isCreditsDialogVisible.value = true },
+            ),
+            TopNavMenuItem(
+                itemNameRes = R.string.menu_item_logout,
+                action = logout,
+            ),
+        )
+    }
+    var isMenuExpanded by rememberSaveable { mutableStateOf(false) }
     TopAppBar(
         title = {
             Column(
@@ -62,7 +87,7 @@ fun TopNavMenu(
                         expanded = isMenuExpanded,
                         onDismissRequest = dismissMenu,
                     ) {
-                        menuItems.forEach { menuItem ->
+                        topNavMenuItems.forEach { menuItem ->
                             DropdownMenuItem(
                                 text = { Text(stringResource(id = menuItem.itemNameRes)) },
                                 onClick = {
@@ -78,28 +103,23 @@ fun TopNavMenu(
     )
 }
 
+@Composable
+private fun DialogHandler(
+    isDialogVisible: MutableState<Boolean>,
+) {
+    if (isDialogVisible.value) {
+        CreditsDialog { isDialogVisible.value = false }
+    }
+}
+
 @ComponentPreviews
 @Composable
 private fun PreviewTopNavMenu() = PassVaultTheme {
     TopNavMenu(
         title = stringResource(id = R.string.app_name),
-        menuItems = arrayOf(
-            TopNavMenuItem(
-                itemNameRes = R.string.menu_item_import_csv,
-                action = {},
-            ),
-            TopNavMenuItem(
-                itemNameRes = R.string.menu_item_export_csv,
-                action = {},
-            ),
-            TopNavMenuItem(
-                itemNameRes = R.string.menu_item_credits,
-                action = {},
-            ),
-            TopNavMenuItem(
-                itemNameRes = R.string.menu_item_logout,
-                action = {},
-            ),
-        )
+        isMenuVisible = true,
+        importCsv = {},
+        exportCsv = {},
+        logout = {},
     )
 }

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountItemDialog.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountItemDialog.kt
@@ -30,7 +30,7 @@ import com.vinsonb.password.manager.kotlin.utilities.ComponentPreviews
 @Composable
 fun ViewAccountItemDialog(
     account: Account,
-    onUpdate: (Account) -> Unit,
+    onUpdate: (Account, Account) -> Unit,
     onDelete: (Account) -> Unit,
     dismissDialog: () -> Unit,
 ) {
@@ -39,6 +39,7 @@ fun ViewAccountItemDialog(
     Dialog(onDismissRequest = dismissDialog) {
         Card(modifier = Modifier.fillMaxWidth()) {
             val isEditEnabled = rememberSaveable { mutableStateOf(false) }
+            val username = rememberSaveable { mutableStateOf(account.username) }
             val password = rememberSaveable { mutableStateOf(account.password) }
 
             Row(
@@ -62,9 +63,10 @@ fun ViewAccountItemDialog(
                             onUpdate(
                                 Account(
                                     platform = account.platform,
-                                    username = account.username,
+                                    username = username.value,
                                     password = password.value,
                                 ),
+                                account,
                             )
                         }
                         isEditEnabled.value = !isEditEnabled.value
@@ -84,9 +86,9 @@ fun ViewAccountItemDialog(
 
             CustomTextField.Normal(
                 modifier = Modifier.padding(horizontal = 16.dp),
-                text = account.username,
-                onTextChange = {},
-                enabled = false,
+                text = username.value,
+                onTextChange = { username.value = it },
+                enabled = isEditEnabled.value,
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.Person,
@@ -100,7 +102,7 @@ fun ViewAccountItemDialog(
                             ClipboardUtilities.copyToClipboard(
                                 context = context,
                                 clipLabel = ClipboardUtilities.CLIP_USERNAME_LABEL,
-                                toCopy = account.username,
+                                toCopy = username.value,
                             )
                         },
                     ) {
@@ -133,7 +135,7 @@ fun ViewAccountItemDialog(
                                 context = context,
                                 clipLabel = ClipboardUtilities.CLIP_PASSWORD_LABEL,
                                 toCopy = password.value,
-                                username = account.username,
+                                username = username.value,
                             )
                         },
                     ) {
@@ -173,7 +175,7 @@ private fun PreviewViewAccountItemDialog() = PassVaultTheme {
             username = "Username@email.com",
             password = "Password",
         ),
-        onUpdate = {},
+        onUpdate = { _, _ -> },
         onDelete = {},
         dismissDialog = {},
     )

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountModels.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountModels.kt
@@ -17,7 +17,13 @@ sealed interface ViewAccountToastState {
         TextResIdProvider by textResIdProvider(R.string.success_deleted_account)
 
     object SuccessfullyUpdated : ViewAccountToastState,
-        TextResIdProvider by textResIdProvider(R.string.success_updated_password)
+        TextResIdProvider by textResIdProvider(R.string.success_updated_account)
+
+    object FailedAccountUpdate : ViewAccountToastState,
+        TextResIdProvider by textResIdProvider(R.string.error_update_unsuccessful)
+
+    object FailedUsernameUpdate : ViewAccountToastState,
+        TextResIdProvider by textResIdProvider(R.string.error_save_unsuccessful)
 
     object Idle : ViewAccountToastState
 }

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountModels.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountModels.kt
@@ -24,5 +24,5 @@ sealed interface ViewAccountToastState {
     object FailedUsernameUpdate : ViewAccountToastState,
         TextResIdProvider by textResIdProvider(R.string.error_save_unsuccessful)
 
-    object Idle : ViewAccountToastState
+    object None : ViewAccountToastState
 }

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountModels.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountModels.kt
@@ -9,7 +9,6 @@ data class ViewAccountState(
     val accounts: List<Account> = emptyList(),
     val searchQuery: String = "",
     val selectedAccount: Account? = null,
-    val toastState: ViewAccountToastState = ViewAccountToastState.Idle,
 )
 
 sealed interface ViewAccountToastState {

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountScreen.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountScreen.kt
@@ -44,7 +44,7 @@ private fun ViewAccountContent(
     state: ViewAccountState,
     onSearch: (String) -> Unit,
     onSelectAccount: (Account) -> Unit,
-    onUpdate: (Account) -> Unit,
+    onUpdate: (Account, Account) -> Unit,
     onDelete: (Account) -> Unit,
     onClearSearch: () -> Unit,
 ) {
@@ -115,7 +115,7 @@ private fun ViewAccountDialogHandler(
     context: Context,
     state: ViewAccountState,
     isDialogVisible: MutableState<Boolean>,
-    onUpdate: (Account) -> Unit,
+    onUpdate: (Account, Account) -> Unit,
     onDelete: (Account) -> Unit,
 ) {
     LaunchedEffect(state.toastState) {
@@ -125,7 +125,7 @@ private fun ViewAccountDialogHandler(
                 context.showToast((state.toastState as TextResIdProvider).getTextResId())
                 isDialogVisible.value = false
             }
-            ViewAccountToastState.SuccessfullyUpdated -> {
+            else -> {
                 context.showToast((state.toastState as TextResIdProvider).getTextResId())
             }
         }
@@ -155,7 +155,7 @@ private fun PreviewViewAccountScreen() = PassVaultTheme {
         ),
         onSearch = {},
         onSelectAccount = {},
-        onUpdate = {},
+        onUpdate = { _, _ -> },
         onDelete = {},
         onClearSearch = {},
     )

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/utilities/Constants.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/utilities/Constants.kt
@@ -3,7 +3,7 @@ package com.vinsonb.password.manager.kotlin.utilities
 object Constants {
     object Password {
         const val PASSCODE_MAX_LENGTH = 5
-        const val PASSCODE_REGEX_PATTERN = "\\d{0,$PASSCODE_MAX_LENGTH}"
+        const val PASSCODE_REGEX_PATTERN = "\\d{1,$PASSCODE_MAX_LENGTH}"
 
         object SharedPreferenceKeys {
             const val PASSCODE_KEY = "passcode"

--- a/app/src/main/java/com/vinsonb/password/manager/kotlin/utilities/EventFlow.kt
+++ b/app/src/main/java/com/vinsonb/password/manager/kotlin/utilities/EventFlow.kt
@@ -11,6 +11,9 @@ interface EventFlow<T> {
     val eventFlow: SharedFlow<T>
 
     fun sendEvent(event: T)
+}
+
+interface SimpleToastEventFlow : EventFlow<SimpleToastEvent> {
     fun resetEvent()
 }
 
@@ -20,7 +23,7 @@ sealed interface SimpleToastEvent {
     object ShowFailed : SimpleToastEvent
 }
 
-fun simpleToastEventFlow(scope: CoroutineScope) = object : EventFlow<SimpleToastEvent> {
+fun simpleToastEventFlow(scope: CoroutineScope) = object : SimpleToastEventFlow {
     private val mutableEventFlow = MutableSharedFlow<SimpleToastEvent>()
     override val eventFlow = mutableEventFlow.asSharedFlow().shareIn(scope)
 
@@ -33,6 +36,17 @@ fun simpleToastEventFlow(scope: CoroutineScope) = object : EventFlow<SimpleToast
     override fun resetEvent() {
         scope.launch {
             mutableEventFlow.emit(SimpleToastEvent.None)
+        }
+    }
+}
+
+fun <Event> eventFlowDelegate(scope: CoroutineScope) = object : EventFlow<Event> {
+    private val mutableEventFlow = MutableSharedFlow<Event>()
+    override val eventFlow = mutableEventFlow.asSharedFlow().shareIn(scope)
+
+    override fun sendEvent(event: Event) {
+        scope.launch {
+            mutableEventFlow.emit(event)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,8 +44,9 @@
     <string name="success_copied_to_clipboard">Successfully copied %1$s to the clipboard!</string>
     <string name="success_passcode_reset">Passcode changed successfully!</string>
     <string name="success_deleted_account">Account deleted successfully!</string>
-    <string name="success_updated_password">Password updated successfully!</string>
+    <string name="success_updated_account">Account updated successfully!</string>
     <string name="error_save_unsuccessful">Account already exists! Use a different username.</string>
+    <string name="error_update_unsuccessful">Account failed to update! Please try again.</string>
     <string name="error_passcode_length">Passcode must be 5 digits</string>
     <string name="error_text_empty">%1$s must not be empty</string>
     <string name="error_password_must_match">Passwords must match</string>

--- a/app/src/test/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeViewModelTest.kt
+++ b/app/src/test/java/com/vinsonb/password/manager/kotlin/ui/features/forgotpasscode/ForgotPasscodeViewModelTest.kt
@@ -4,12 +4,10 @@ import app.cash.turbine.test
 import com.vinsonb.password.manager.kotlin.runCancellingTest
 import com.vinsonb.password.manager.kotlin.utilities.Constants.Password.PASSCODE_MAX_LENGTH
 import com.vinsonb.password.manager.kotlin.utilities.SimpleToastEvent
-import com.vinsonb.password.manager.kotlin.utilities.isValidPasscodeInput
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import junitparams.naming.TestCaseName
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -38,15 +36,13 @@ class ForgotPasscodeViewModelTest {
     ) = runCancellingTest {
         // Arrange
         val viewModel = provideViewModel()
-        viewModel.showDialog()
 
         // Act
         viewModel.validateSecretAnswer(secretAnswer)
 
         // Assert
         viewModel.stateFlow.test {
-            val actualError = (awaitItem() as ForgotPasscodeState.Visible).secretAnswerError
-            assertEquals(expectedError, actualError)
+            assertEquals(expectedError, awaitItem().secretAnswerError)
         }
     }
 
@@ -71,15 +67,13 @@ class ForgotPasscodeViewModelTest {
     ) = runCancellingTest {
         // Arrange
         val viewModel = provideViewModel()
-        viewModel.showDialog()
 
         // Act
         viewModel.validatePasscode(passcode, repeatPasscode)
 
         // Assert
         viewModel.stateFlow.test {
-            val actualError = (awaitItem() as ForgotPasscodeState.Visible).passcodeError
-            assertEquals(expectedError, actualError)
+            assertEquals(expectedError, awaitItem().passcodeError)
         }
     }
 
@@ -105,25 +99,21 @@ class ForgotPasscodeViewModelTest {
     ) = runCancellingTest {
         // Arrange
         val viewModel = provideViewModel()
-        viewModel.showDialog()
 
         // Act
         viewModel.validateRepeatPasscode(passcode, repeatPasscode)
 
         // Assert
         viewModel.stateFlow.test {
-            val actualError = (awaitItem() as ForgotPasscodeState.Visible).repeatPasscodeError
-            assertEquals(expectedError, actualError)
+            assertEquals(expectedError, awaitItem().repeatPasscodeError)
         }
     }
 
     @Test
-    fun `GIVEN saveNewPasscode succeeded WHEN resetPasscode invoked THEN verify state changed to hidden and toast event succeeded`() =
+    fun `GIVEN saveNewPasscode succeeded WHEN resetPasscode invoked THEN verify toast event succeeded`() =
         runCancellingTest {
             // Arrange
             val viewModel = provideViewModel()
-            viewModel.showDialog()
-            assertEquals(ForgotPasscodeState.Visible(), viewModel.stateFlow.first())
 
             viewModel.eventFlow.test {
                 // Act
@@ -131,11 +121,6 @@ class ForgotPasscodeViewModelTest {
 
                 // Assert
                 assertEquals(SimpleToastEvent.ShowSucceeded, awaitItem())
-            }
-
-            // Assert dialog also dismissed
-            viewModel.stateFlow.test {
-                assertEquals(ForgotPasscodeState.Hidden, awaitItem())
             }
         }
 
@@ -146,7 +131,6 @@ class ForgotPasscodeViewModelTest {
             val viewModel = provideViewModel(
                 saveNewPasscodeReturn = false,
             )
-            viewModel.showDialog()
 
             viewModel.eventFlow.test {
                 // Act
@@ -154,66 +138,6 @@ class ForgotPasscodeViewModelTest {
 
                 // Assert
                 assertEquals(SimpleToastEvent.ShowFailed, awaitItem())
-            }
-        }
-
-    @Test
-    @Parameters(
-        value = [
-            "asf,false",
-            "aasffsafs,false",
-            "wrong,false",
-            "-=2as,false",
-            "123456,false",
-            ",true",
-            "123,true",
-            "12345,true",
-        ]
-    )
-    @TestCaseName("GIVEN {0} as passcode WHEN isValidPasscodeInput invoked THEN return {1}")
-    fun `isValidPasscodeInput parameterised test`(
-        passcode: String = "",
-        expected: Boolean,
-    ) = runCancellingTest {
-        // Arrange
-        val viewModel = provideViewModel()
-
-        // Act
-        val result = isValidPasscodeInput(passcode)
-
-        // Assert
-        assertEquals(expected, result)
-    }
-
-    @Test
-    fun `GIVEN state hidden WHEN showDialog invoked THEN change state to visible`() =
-        runCancellingTest {
-            // Arrange
-            val viewModel = provideViewModel()
-
-            // Act
-            viewModel.showDialog()
-
-            // Assert
-            viewModel.stateFlow.test {
-                assertEquals(ForgotPasscodeState.Visible(), awaitItem())
-            }
-        }
-
-    @Test
-    fun `GIVEN state visible WHEN dismissDialog invoked THEN change state to hidden`() =
-        runCancellingTest {
-            // Arrange
-            val viewModel = provideViewModel()
-            viewModel.showDialog()
-            assertEquals(ForgotPasscodeState.Visible(), viewModel.stateFlow.first())
-
-            // Act
-            viewModel.dismissDialog()
-
-            // Assert
-            viewModel.stateFlow.test {
-                assertEquals(ForgotPasscodeState.Hidden, awaitItem())
             }
         }
 

--- a/app/src/test/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountViewModelTest.kt
+++ b/app/src/test/java/com/vinsonb/password/manager/kotlin/ui/features/viewaccount/ViewAccountViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.vinsonb.password.manager.kotlin.database.enitities.Account
 import com.vinsonb.password.manager.kotlin.runCancellingTest
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotSame
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -75,24 +76,23 @@ class ViewAccountViewModelTest {
                 updateAccount = mockFunctions::updateAccount,
             )
 
-            // Act
-            viewModel.onUpdateAccount(
-                account = Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "NewPassword"
-                ),
-                originalAccount = Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "Password"
-                ),
-            )
+            viewModel.eventFlow.test {
+                // Act
+                viewModel.onUpdateAccount(
+                    account = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "NewPassword"
+                    ),
+                    originalAccount = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "Password"
+                    ),
+                )
 
-            // Assert
-            viewModel.stateFlow.test {
-                assertEquals(ViewAccountToastState.SuccessfullyUpdated, awaitItem().toastState)
-                assertEquals(ViewAccountToastState.Idle, awaitItem().toastState)
+                // Assert
+                assertEquals(ViewAccountToastState.SuccessfullyUpdated, awaitItem())
             }
 
             verify(mockFunctions, times(0)).deleteAccount(any())
@@ -110,25 +110,29 @@ class ViewAccountViewModelTest {
                 insertAccount = mockFunctions::insertAccount,
                 updateAccount = mockFunctions::updateAccount,
             )
-
-            // Act
-            viewModel.onUpdateAccount(
-                account = Account(
-                    platform = "Platform",
-                    username = "NewUsername",
-                    password = "NewPassword"
-                ),
-                originalAccount = Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "Password"
-                ),
+            val account = Account(
+                platform = "Platform",
+                username = "NewUsername",
+                password = "NewPassword"
             )
 
-            // Assert
+            viewModel.eventFlow.test {
+                // Act
+                viewModel.onUpdateAccount(
+                    account = account,
+                    originalAccount = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "Password"
+                    ),
+                )
+
+                // Assert
+                assertEquals(ViewAccountToastState.SuccessfullyUpdated, awaitItem())
+            }
+
             viewModel.stateFlow.test {
-                assertEquals(ViewAccountToastState.SuccessfullyUpdated, awaitItem().toastState)
-                assertEquals(ViewAccountToastState.Idle, awaitItem().toastState)
+                assertEquals(account, awaitItem().selectedAccount)
             }
 
             verify(mockFunctions, times(1)).deleteAccount(any())
@@ -149,24 +153,23 @@ class ViewAccountViewModelTest {
                 updateAccount = mockFunctions::updateAccount,
             )
 
-            // Act
-            viewModel.onUpdateAccount(
-                account = Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "NewPassword"
-                ),
-                originalAccount = Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "Password"
-                ),
-            )
+            viewModel.eventFlow.test {
+                // Act
+                viewModel.onUpdateAccount(
+                    account = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "NewPassword"
+                    ),
+                    originalAccount = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "Password"
+                    ),
+                )
 
-            // Assert
-            viewModel.stateFlow.test {
-                assertEquals(ViewAccountToastState.FailedAccountUpdate, awaitItem().toastState)
-                assertEquals(ViewAccountToastState.Idle, awaitItem().toastState)
+                // Assert
+                assertEquals(ViewAccountToastState.FailedAccountUpdate, awaitItem())
             }
 
             verify(mockFunctions, times(0)).deleteAccount(any())
@@ -186,25 +189,29 @@ class ViewAccountViewModelTest {
                 insertAccount = mockFunctions::insertAccount,
                 updateAccount = mockFunctions::updateAccount,
             )
-
-            // Act
-            viewModel.onUpdateAccount(
-                Account(
-                    platform = "Platform",
-                    username = "NewUsername",
-                    password = "NewPassword"
-                ),
-                Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "Password"
-                ),
+            val account = Account(
+                platform = "Platform",
+                username = "NewUsername",
+                password = "NewPassword"
             )
 
-            // Assert
+            viewModel.eventFlow.test {
+                // Act
+                viewModel.onUpdateAccount(
+                    account = account,
+                    originalAccount = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "Password"
+                    ),
+                )
+
+                // Assert
+                assertEquals(ViewAccountToastState.FailedUsernameUpdate, awaitItem())
+            }
+
             viewModel.stateFlow.test {
-                assertEquals(ViewAccountToastState.FailedUsernameUpdate, awaitItem().toastState)
-                assertEquals(ViewAccountToastState.Idle, awaitItem().toastState)
+                assertNotSame(account, awaitItem().selectedAccount)
             }
 
             verify(mockFunctions, times(0)).deleteAccount(any())
@@ -224,25 +231,29 @@ class ViewAccountViewModelTest {
                 insertAccount = mockFunctions::insertAccount,
                 updateAccount = mockFunctions::updateAccount,
             )
-
-            // Act
-            viewModel.onUpdateAccount(
-                Account(
-                    platform = "Platform",
-                    username = "NewUsername",
-                    password = "NewPassword"
-                ),
-                Account(
-                    platform = "Platform",
-                    username = "Username1",
-                    password = "Password"
-                ),
+            val account = Account(
+                platform = "Platform",
+                username = "NewUsername",
+                password = "NewPassword"
             )
 
-            // Assert
+            viewModel.eventFlow.test {
+                // Act
+                viewModel.onUpdateAccount(
+                    account = account,
+                    originalAccount = Account(
+                        platform = "Platform",
+                        username = "Username1",
+                        password = "Password"
+                    ),
+                )
+
+                // Assert
+                assertEquals(ViewAccountToastState.FailedAccountUpdate, awaitItem())
+            }
+
             viewModel.stateFlow.test {
-                assertEquals(ViewAccountToastState.FailedAccountUpdate, awaitItem().toastState)
-                assertEquals(ViewAccountToastState.Idle, awaitItem().toastState)
+                assertNotSame(account, awaitItem().selectedAccount)
             }
 
             verify(mockFunctions, times(2)).deleteAccount(any())
@@ -256,19 +267,18 @@ class ViewAccountViewModelTest {
             // Arrange
             val viewModel = provideViewModel()
 
-            // Act
-            viewModel.onDeleteAccount(
-                Account(
-                    platform = "NewPlatform",
-                    username = "NewUsername",
-                    password = "NewPassword"
+            viewModel.eventFlow.test {
+                // Act
+                viewModel.onDeleteAccount(
+                    Account(
+                        platform = "NewPlatform",
+                        username = "NewUsername",
+                        password = "NewPassword"
+                    )
                 )
-            )
 
-            // Assert
-            viewModel.stateFlow.test {
-                assertEquals(ViewAccountToastState.SuccessfullyDeleted, awaitItem().toastState)
-                assertEquals(ViewAccountToastState.Idle, awaitItem().toastState)
+                // Assert
+                assertEquals(ViewAccountToastState.SuccessfullyDeleted, awaitItem())
             }
         }
 

--- a/app/src/test/java/com/vinsonb/password/manager/kotlin/utilities/PasscodeUtilitiesTest.kt
+++ b/app/src/test/java/com/vinsonb/password/manager/kotlin/utilities/PasscodeUtilitiesTest.kt
@@ -21,7 +21,7 @@ class PasscodeUtilitiesTest {
             "wrong,false",
             "-=2as,false",
             "123456,false",
-            ",true",
+            ",false",
             "123,true",
             "12345,true",
         ]


### PR DESCRIPTION
### Description
- Added username editing feature
- Changed View Account toast event handling. Will also extract the remaining eventFlow from the MainActivity and follow this design.
- Redesigned Toast Event Handling and extracted all toast related logic from MainActivity to their individual screens.
- Extracted ForgotPasscodeViewModel Dialog Handling out of ViewModel so it will be consistent with the rest of the Dialogs.
- Updated Unit ForgotPasscodeViewModelTest to reflect changes Dialog Handling logic.
- Deleted duplicate test in ForgotPasscodeViewModelTest that was already handled in PassocdeUtilitiesTest.
- Updated PasscodeUtililities RegEx to have a minimum of 1 digit instead of 0 for valid passcodes. Updated its test to reflect this change as well.
- Extracted Credit Dialog Handling to Top Nav Menu.

### Type of Change
- [X] New feature 
- [X] Refactor
